### PR TITLE
fix(api): resolve issue #50 by restoring single-position support in g…

### DIFF
--- a/server/utils/gene.js
+++ b/server/utils/gene.js
@@ -89,11 +89,8 @@ exports.getByGenomicLocation = (chr, posStart, posStop, build) => {
       // range query
       query = {
         chr,
-        $or: [
-          { [startField]: { $gte: posStart, $lte: posStop } },
-          { [stopField]: { $gte: posStart, $lte: posStop } },
-          { [startField]: { $lte: posStart }, [stopField]: { $gte: posStop } },
-        ]
+        [startField]: { $lte: posStop },
+        [stopField]: { $gte: posStart }
       };
     }
     Genes.find(query, { _id: 0, clinVarIds: 0, gos: 0, dgvIds: 0, decipherIds: 0, geno2mpIds: 0,


### PR DESCRIPTION
…ene lookup

Fixed the issue where querying genes by a single genomic position returned no results after refactoring for range-based queries. Re-added logic to handle exact position matches.